### PR TITLE
fixed: typo in the HiveBox projects

### DIFF
--- a/docs/projects/hivebox/README.md
+++ b/docs/projects/hivebox/README.md
@@ -58,7 +58,7 @@ This project works best in `Pairing` mode, where you have another person to help
 
 - Avoid stereotypes about yourself! You have to think differently this time!
 - Say `NO` more to other things during the project implementation. Even good things, i.e., stay focused!
-- Remember, life is all about tread-offs! [You can do anything if you stop trying to do everything](https://www.oliveremberton.com/p/you-can-do-anything-if-you-stop-trying).
+- Remember, life is all about trade-offs! [You can do anything if you stop trying to do everything](https://www.oliveremberton.com/p/you-can-do-anything-if-you-stop-trying).
 
 :::note
 Each phase of this project is tackled gradually as part of the roadmap modules. But it's also **standalone**, and you can work on it if you have the required knowledge for each phase.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Corrected a typo in the Hivebox project README Tips section, changing “tread-offs” to “trade-offs” for improved clarity and polish. This update enhances readability for users consulting the documentation. No functional or behavioral changes are included in this release. No updates to user flows, APIs, or configuration are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->